### PR TITLE
Use `echidna-version` action input key

### DIFF
--- a/.github/workflows/echidna.yml
+++ b/.github/workflows/echidna.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Node
         uses: actions/setup-node@v2
@@ -30,14 +30,15 @@ jobs:
         run: yarn build
 
       - name: Fuzz ${{ matrix.testName}}
-        uses: crytic/echidna-action@v1
+        uses: crytic/echidna-action@v2
         with:
           files: .
           contract: ${{ matrix.testName }}
           config: echidna.config.ci.yml
           format: text
-          check-asserts: true
+          test-mode: assertion
           test-limit: 50000
           seq-len: 100
           solc-version: 0.8.4
+          echidna-version: v2.0.0
           crytic-args: --hardhat-ignore-compile


### PR DESCRIPTION
- Use `echidna-version` action input key introduced in `echidna-action@v2`
- Bump CI to echidna `v2.0.0`
- Minor changes